### PR TITLE
Add nginx, unit, and perl to subset

### DIFF
--- a/subset.txt
+++ b/subset.txt
@@ -14,10 +14,13 @@ logstash
 memcached
 mongo
 mysql
+nginx
 notary
 openjdk
+perl
 postgres
 rabbitmq
 redis
 redmine
+unit
 wordpress


### PR DESCRIPTION
@thresheek @zakame how do y'all feel about being guinea pigs for our new build infra? :eyes:

The end result of the images should be ~identical (it's pretty low risk now that we've got so many images moved over already, and we _do_ intend to move everyone/everything over eventually but we're taking it slow/careful), but with expanded provenance data (including SBOM) from newer buildx/buildkit that you can see on images we've already moved over like https://explore.ggcr.dev/?image=docker :eyes:

For example, this embeds the `Dockerfile` directly in the objects pushed, if you click down in far enough: https://explore.ggcr.dev/?blob=docker%40sha256%3A833050322595ba816be5dc14cff90dfc23e31dd5097fb41a5902a1e9e1efab47&jq=.predicate.metadata%5B%22https%3A%2F%2Fmobyproject.org%2Fbuildkit%40v1%23metadata%22%5D.source.infos%5B0%5D.data&jq=base64+-d&mt=application%2Fvnd.in-toto%2Bjson&render=raw&size=35751 :smile:

For @zakame specifically, the annotations this adds might be an interesting extra justification for my suggestion in https://github.com/Perl/docker-perl/issues/150, if you have hesitations due to traceability/provenance :smile: