### PR TITLE
Add xwiki and elixir to subset

### DIFF
--- a/subset.txt
+++ b/subset.txt
@@ -5,6 +5,7 @@ cirros
 docker
 drupal
 elasticsearch
+elixir
 gcc
 ghost
 haproxy
@@ -28,3 +29,4 @@ redis
 redmine
 unit
 wordpress
+xwiki


### PR DESCRIPTION
Migrates xwiki and elixir to the new build

@tmortagne @manuelleduc @getong are you ok with this change? The only change is manifest is going to use the OCI format and the image will come with attestation for included software