### PR TITLE
Add MariaDB

### DIFF
--- a/subset.txt
+++ b/subset.txt
@@ -17,6 +17,7 @@ irssi
 julia
 kibana
 logstash
+mariadb
 memcached
 mongo
 mysql


### PR DESCRIPTION
@grooverdan this migrates MariaDB to the build system which uses builkit. The only change is to the manifest of the image, not to the content of the image. The manifest format changes to the OCI format and the manifest will include Software attestations