### PR TITLE
Initial signing prototype

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ run-name: '${{ inputs.bashbrewArch }}: ${{ inputs.firstTag }} (${{ inputs.buildI
 permissions:
   contents: read
   actions: write # for https://github.com/andymckay/cancel-action (see usage below)
+  id-token: write # for AWS KMS signing (see usage below)
 concurrency:
   group: ${{ github.event.inputs.buildId }}
   cancel-in-progress: false
@@ -105,6 +106,11 @@ jobs:
 
           mkdir build
 
+          # TODO signing prototype -- starting very small
+          shouldSign="$(jq <<<"$json" '.build.arch == "amd64" and any(.source.allTags[]; startswith("notary:"))')"
+          [ "$shouldSign" = 'true' ] || [ "$shouldSign" = 'false' ] || exit 1
+          echo "shouldSign=$shouldSign" >> "$GITHUB_ENV"
+
       - name: Check
         run: |
           img="$(jq <<<"$json" -r '.build.img')"
@@ -144,6 +150,122 @@ jobs:
             eval "$bk"
           fi
           eval "$shell"
+
+      # TODO signing prototype (see above where "shouldSign" is populated)
+      - name: Configure AWS (for signing)
+        if: env.shouldSign == 'true'
+        # https://github.com/aws-actions/configure-aws-credentials/releases
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          # TODO drop "subset" (github.ref_name == "main" && ... || ...)
+          aws-region:     ${{ contains(fromJSON('["main","subset"]', github.ref_name) && secrets.AWS_KMS_PROD_REGION   || secrets.AWS_KMS_STAGE_REGION }}
+          role-to-assume: ${{ contains(fromJSON('["main","subset"]', github.ref_name) && secrets.AWS_KMS_PROD_ROLE_ARN || secrets.AWS_KMS_STAGE_ROLE_ARN }}
+          # TODO figure out if there's some way we could make our secrets ternaries here more DRY without major headaches 🙈
+      - name: Sign
+        if: env.shouldSign == 'true'
+        env:
+          AWS_KMS_REGION:  ${{ contains(fromJSON('["main","subset"]', github.ref_name) && secrets.AWS_KMS_PROD_REGION  || secrets.AWS_KMS_STAGE_REGION }}
+          AWS_KMS_KEY_ARN: ${{ contains(fromJSON('["main","subset"]', github.ref_name) && secrets.AWS_KMS_PROD_KEY_ARN || secrets.AWS_KMS_STAGE_KEY_ARN }}
+        run: |
+          cd build
+
+          args=(
+            --interactive
+            --rm
+            --read-only
+            --workdir /tmp # see "--tmpfs" below (TODO the signer currently uses PWD as TMPDIR -- something to fix in the future so we can drop this --workdir and only keep --tmpfs perhaps adding --env TMPDIR=/tmp if necessary)
+          )
+          if [ -t 0 ] && [ -t 1 ]; then
+            args+=( --tty )
+          fi
+
+          user="$(id -u)"
+          args+=( --tmpfs "/tmp:uid=$user" )
+          user+=":$(id -g)"
+          args+=( --user "$user" )
+
+          awsEnvs=( "${!AWS_@}" )
+          args+=( "${awsEnvs[@]/#/--env=}" )
+
+          # some very light assumption verification (see TODO in --mount below)
+          validate-oci-layout() {
+            local dir="$1"
+            jq -s '
+              if length != 1 then
+                error("unexpected 'oci-layout' document count: " + length)
+              else .[0] end
+              | if .imageLayoutVersion != "1.0.0" then
+                error("unsupported imageLayoutVersion: " + .imageLayoutVersion)
+              else . end
+            ' "$dir/oci-layout" || return "$?"
+            jq -s '
+              if length != 1 then
+                error("unexpected 'index.json' document count: " + length)
+              else .[0] end
+
+              | if .schemaVersion != 2 then
+                error("unsupported schemaVersion: " + .schemaVersion)
+              else . end
+              | if .mediaType != "application/vnd.oci.image.index.v1+json" and .mediaType then # TODO drop the second half of this validation: https://github.com/moby/buildkit/issues/4595
+                error("unsupported index mediaType: " + .mediaType)
+              else . end
+              | if .manifests | length != 1 then
+                error("expected only one manifests entry, not " + (.manifests | length))
+              else . end
+
+              | .manifests[0] |= (
+                if .mediaType != "application/vnd.oci.image.index.v1+json" then
+                  error("unsupported descriptor mediaType: " + .mediaType)
+                else . end
+                # TODO validate .digest somehow (`crane validate`?) - would also be good to validate all descriptors recursively
+                | if .size < 0 then
+                  error("invalid descriptor size: " + .size)
+                else . end
+              )
+            ' "$dir/index.json" || return "$?"
+            local manifest
+            manifest="$dir/blobs/$(jq -r '.manifests[0].digest | sub(":"; "/")' "$dir/index.json")" || return "$?"
+            jq -s '
+              if length != 1 then
+                error("unexpected image index document count: " + length)
+              else .[0] end
+              | if .schemaVersion != 2 then
+                error("unsupported schemaVersion: " + .schemaVersion)
+              else . end
+              | if .mediaType != "application/vnd.oci.image.index.v1+json" then
+                error("unsupported image index mediaType: " + .mediaType)
+              else . end
+
+              # TODO more validation?
+            ' "$manifest" || return "$?"
+          }
+          validate-oci-layout temp
+
+          mkdir signed
+
+          args+=(
+            --mount "type=bind,src=$PWD/temp,dst=/doi-build/unsigned" # TODO this currently assumes normalized_builder == "buildkit" and !should_use_docker_buildx_driver -- we need to factor that in later (although this signs the attestations, not the image, so buildkit/buildx is the only builder whose output we *can* sign right now)
+            --mount "type=bind,src=$PWD/signed,dst=/doi-build/signed"
+
+            docker/image-signer-verifier:0.3.2@sha256:7f5b2da65febf32d88ef6283b36c6af79e05df6e2bb7a7a930d6ea81f58b3757
+
+            sign
+
+            --aws_region "$AWS_KMS_REGION"
+            --aws_arn "awskms:///$AWS_KMS_KEY_ARN"
+
+            --input oci:///doi-build/unsigned
+            --output oci:///doi-build/signed
+          )
+
+          docker run "${args[@]}"
+
+          validate-oci-layout signed
+
+          # TODO validate that "signed" still has all the original layer blobs from "temp" (ie, that the attestation manifest *just* has some new layers and everything else is unchanged)
+
+          rm -rf temp
+          mv signed temp
 
       - name: Push
         env:


### PR DESCRIPTION
See https://github.com/docker-library/meta/actions/runs/7701877067/job/20988927236 for an example that successfully/correctly skips signing on `drupal` and https://github.com/docker-library/meta/actions/runs/7701710200/job/20988396507 for an example that successfully signed `notary:server-0.7.0` with the staging KMS.

https://github.com/docker-library/meta/compare/a0d19a7..9ce2ae9 is roughly the delta between those jobs and this PR -- the final `exit 1` there was obviously removed for the `notary` push that was successful.

You can see the very experimental signed object pushed by that `notary` job at https://oci.dag.dev/?image=oisupport/staging-amd64@sha256:7837e541963287ae44f4eabfbf9259c9e935bdf6f9a2451c7a35cdcca57c6b28 (signed by the staging key, not the production key, so I'll have to wipe that out _and_ our cache of the build to get it to rebuild and sign with the production key).

(Testing and debugging GitHub Actions is really awful -- long term, this "Sign" action code probably needs to live in `meta-scripts` as a new script, which solves part of the problem but not all of it.)