### PR TITLE
Add swipl to new builds to fix build failures

### DIFF
--- a/subset.txt
+++ b/subset.txt
@@ -36,6 +36,7 @@ ruby
 rust
 solr
 sonarqube
+swipl
 unit
 wordpress
 xwiki


### PR DESCRIPTION
This is one option to attempt to address the failures noted here: https://github.com/docker-library/official-images/pull/16167#issuecomment-1927693420.

Alternatively, we can continue to debug why the `amd64` image fails to build on our AWS instance but builds fine locally and on GitHub Actions or have the maintainer apply one of the [other possible solutions](https://github.com/docker-library/official-images/pull/16167#issuecomment-1929189805) (back to `bullseye` or change `g++` flags).

We are in a little pause of adding new items because of scaling (https://github.com/docker-library/meta-scripts/issues/22), but I think this can warrant earlier access since it should fix the failing build.