### PR TITLE
Add timeout to wget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
             local target="$1"; shift
             local url="$1"; shift
             if command -v wget > /dev/null; then
-              wget -O "$target" "$url" --progress=dot:giga
+              wget --timeout=5 -O "$target" "$url" --progress=dot:giga
             else
               curl -fL -o "$target" "$url"
             fi


### PR DESCRIPTION
This isn't operationally necessary but is good practice. Not sure a good timeout option to add to the `curl`, since it doesn't have one with this same semantics.

Similar to https://github.com/docker-library/oi-janky-groovy/pull/40 and https://github.com/docker-library/meta-scripts/pull/69