### PR TITLE
Drop references to (defunct/renamed) `subset` branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,15 +157,14 @@ jobs:
         # https://github.com/aws-actions/configure-aws-credentials/releases
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          # TODO drop "subset" (github.ref_name == "main" && ... || ...)
-          aws-region:     ${{ contains(fromJSON('["main","subset"]'), github.ref_name) && secrets.AWS_KMS_PROD_REGION   || secrets.AWS_KMS_STAGE_REGION }}
-          role-to-assume: ${{ contains(fromJSON('["main","subset"]'), github.ref_name) && secrets.AWS_KMS_PROD_ROLE_ARN || secrets.AWS_KMS_STAGE_ROLE_ARN }}
+          aws-region:     ${{ github.ref_name == "main" && secrets.AWS_KMS_PROD_REGION   || secrets.AWS_KMS_STAGE_REGION }}
+          role-to-assume: ${{ github.ref_name == "main" && secrets.AWS_KMS_PROD_ROLE_ARN || secrets.AWS_KMS_STAGE_ROLE_ARN }}
           # TODO figure out if there's some way we could make our secrets ternaries here more DRY without major headaches 🙈
       - name: Sign
         if: env.shouldSign == 'true'
         env:
-          AWS_KMS_REGION:  ${{ contains(fromJSON('["main","subset"]'), github.ref_name) && secrets.AWS_KMS_PROD_REGION  || secrets.AWS_KMS_STAGE_REGION }}
-          AWS_KMS_KEY_ARN: ${{ contains(fromJSON('["main","subset"]'), github.ref_name) && secrets.AWS_KMS_PROD_KEY_ARN || secrets.AWS_KMS_STAGE_KEY_ARN }}
+          AWS_KMS_REGION:  ${{ github.ref_name == "main" && secrets.AWS_KMS_PROD_REGION  || secrets.AWS_KMS_STAGE_REGION }}
+          AWS_KMS_KEY_ARN: ${{ github.ref_name == "main" && secrets.AWS_KMS_PROD_KEY_ARN || secrets.AWS_KMS_STAGE_KEY_ARN }}
         run: |
           cd build
 


### PR DESCRIPTION
See https://github.com/docker-library/meta-scripts/pull/85

This isn't strictly _necessary_ (given the conditionals in question were already accounting for this move), but it's a good follow-up cleanup (and opening it now makes me feel better about having a record of checking for dependencies in _this_ repository on the `subset` branch name).