### PR TITLE
Add Windows Server ltsc2025 to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ on:
         type: choice
         options:
           - '' # without this, it's technically "required" 🙃
+          - 2025
           - 2022
           - 2019
 run-name: '${{ inputs.bashbrewArch }}: ${{ inputs.firstTag }} (${{ inputs.buildId }})'


### PR DESCRIPTION
From `windows-amd64>trigger` jobs:
```console
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 48   439    0     0  100   212      0    615 --:--:-- --:--:-- --:--:--   616
curl: (22) The requested URL returned error: 422
ERROR: script returned exit code 22
...
ERROR: Build of "golang:1.24rc2-windowsservercore-ltsc2025" failed
```
Jobs aren't able to trigger GHA without 2025 being an option in the list. 😆🤦

Related to https://github.com/docker-library/official-images/pull/18143