### PR TITLE
Remove PoC signing prototype

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ run-name: '${{ inputs.bashbrewArch }}: ${{ inputs.firstTag }} (${{ inputs.buildI
 permissions:
   contents: read
   actions: write # for https://github.com/andymckay/cancel-action (see usage below)
-  id-token: write # for AWS KMS signing (see usage below)
 concurrency:
   group: ${{ github.event.inputs.buildId }}
   cancel-in-progress: false
@@ -96,7 +95,6 @@ jobs:
               .[env.BUILD_ID]
               | select(needs_build and .build.arch == env.BASHBREW_ARCH) # sanity check
               | .commands = commands
-              | .shouldSign = build_should_sign
             ' builds.json
           )"
           [ -n "$json" ]
@@ -148,124 +146,6 @@ jobs:
             eval "$bk"
           fi
           eval "$shell"
-
-      # TODO signing prototype (see above where "shouldSign" is populated)
-      - name: Configure AWS (for signing)
-        if: fromJSON(steps.json.outputs.json).shouldSign
-        # https://github.com/aws-actions/configure-aws-credentials/releases
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
-        with:
-          aws-region:     ${{ github.ref_name == 'main' && secrets.AWS_KMS_PROD_REGION   || secrets.AWS_KMS_STAGE_REGION }}
-          role-to-assume: ${{ github.ref_name == 'main' && secrets.AWS_KMS_PROD_ROLE_ARN || secrets.AWS_KMS_STAGE_ROLE_ARN }}
-          # TODO figure out if there's some way we could make our secrets ternaries here more DRY without major headaches 🙈
-      - name: Sign
-        if: fromJSON(steps.json.outputs.json).shouldSign
-        env:
-          AWS_KMS_REGION:  ${{ github.ref_name == 'main' && secrets.AWS_KMS_PROD_REGION  || secrets.AWS_KMS_STAGE_REGION }}
-          AWS_KMS_KEY_ARN: ${{ github.ref_name == 'main' && secrets.AWS_KMS_PROD_KEY_ARN || secrets.AWS_KMS_STAGE_KEY_ARN }}
-        run: |
-          cd build
-
-          args=(
-            --interactive
-            --rm
-            --read-only
-            --workdir /tmp # see "--tmpfs" below (TODO the signer currently uses PWD as TMPDIR -- something to fix in the future so we can drop this --workdir and only keep --tmpfs perhaps adding --env TMPDIR=/tmp if necessary)
-          )
-          if [ -t 0 ] && [ -t 1 ]; then
-            args+=( --tty )
-          fi
-
-          user="$(id -u)"
-          args+=( --tmpfs "/tmp:uid=$user" )
-          user+=":$(id -g)"
-          args+=( --user "$user" )
-
-          awsEnvs=( "${!AWS_@}" )
-          args+=( "${awsEnvs[@]/#/--env=}" )
-
-          # some very light assumption verification (see TODO in --mount below)
-          validate-oci-layout() {
-            local dir="$1"
-            jq -s '
-              if length != 1 then
-                error("unexpected 'oci-layout' document count: " + length)
-              else .[0] end
-              | if .imageLayoutVersion != "1.0.0" then
-                error("unsupported imageLayoutVersion: " + .imageLayoutVersion)
-              else . end
-            ' "$dir/oci-layout" || return "$?"
-            jq -s '
-              if length != 1 then
-                error("unexpected 'index.json' document count: " + length)
-              else .[0] end
-
-              | if .schemaVersion != 2 then
-                error("unsupported schemaVersion: " + .schemaVersion)
-              else . end
-              | if .mediaType != "application/vnd.oci.image.index.v1+json" and .mediaType then # TODO drop the second half of this validation: https://github.com/moby/buildkit/issues/4595
-                error("unsupported index mediaType: " + .mediaType)
-              else . end
-              | if .manifests | length != 1 then
-                error("expected only one manifests entry, not " + (.manifests | length))
-              else . end
-
-              | .manifests[0] |= (
-                if .mediaType != "application/vnd.oci.image.index.v1+json" then
-                  error("unsupported descriptor mediaType: " + .mediaType)
-                else . end
-                # TODO validate .digest somehow (`crane validate`?) - would also be good to validate all descriptors recursively
-                | if .size < 0 then
-                  error("invalid descriptor size: " + .size)
-                else . end
-              )
-            ' "$dir/index.json" || return "$?"
-            local manifest
-            manifest="$dir/blobs/$(jq -r '.manifests[0].digest | sub(":"; "/")' "$dir/index.json")" || return "$?"
-            jq -s '
-              if length != 1 then
-                error("unexpected image index document count: " + length)
-              else .[0] end
-              | if .schemaVersion != 2 then
-                error("unsupported schemaVersion: " + .schemaVersion)
-              else . end
-              | if .mediaType != "application/vnd.oci.image.index.v1+json" then
-                error("unsupported image index mediaType: " + .mediaType)
-              else . end
-
-              # TODO more validation?
-            ' "$manifest" || return "$?"
-          }
-          validate-oci-layout temp
-
-          mkdir signed
-
-          args+=(
-            --mount "type=bind,src=$PWD/temp,dst=/doi-build/unsigned" # TODO this currently assumes normalized_builder == "buildkit" and !should_use_docker_buildx_driver -- we need to factor that in later (although this signs the attestations, not the image, so buildkit/buildx is the only builder whose output we *can* sign right now)
-            --mount "type=bind,src=$PWD/signed,dst=/doi-build/signed"
-
-            # https://explore.ggcr.dev/?repo=docker/image-signer-verifier
-            docker/image-signer-verifier:0.3.3@sha256:a5351e6495596429bacea85fbf8f41a77ce7237c26c74fd7c3b94c3e6d409c82
-
-            sign
-
-            --envelope-style oci-content-descriptor
-
-            --aws_region "$AWS_KMS_REGION"
-            --aws_arn "awskms:///$AWS_KMS_KEY_ARN"
-
-            --input oci:///doi-build/unsigned
-            --output oci:///doi-build/signed
-          )
-
-          docker run "${args[@]}"
-
-          validate-oci-layout signed
-
-          # TODO validate that "signed" still has all the original layer blobs from "temp" (ie, that the attestation manifest *just* has some new layers and everything else is unchanged)
-
-          rm -rf temp
-          mv signed temp
 
       - name: Push
         env:


### PR DESCRIPTION
The replacement for this is still a WIP, but as-is this should not be used and thus should not continue to be invoked here in any cases (even though those cases are still very tightly controlled via `build_should_sign` in `doi.jq`).