### PR TITLE
Add `BASHBREW_META_SCRIPTS`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
   build:
     name: Build ${{ inputs.buildId }}
     runs-on: ${{ inputs.bashbrewArch == 'windows-amd64' && format('windows-{0}', inputs.windowsVersion) || 'ubuntu-latest' }}
+    env:
+      BASHBREW_META_SCRIPTS: ${{ github.workspace }}/.scripts
     steps:
 
       - name: Checkout
@@ -89,7 +91,7 @@ jobs:
         id: json
         run: |
           json="$(
-            jq -L.scripts '
+            jq -L"$BASHBREW_META_SCRIPTS" '
               include "meta";
               include "doi";
               .[env.BUILD_ID]


### PR DESCRIPTION
This isn't used in `main` yet, but will be used soon.  This allows us to avoid constantly repeating "find the directory" code in favor of a cleaner high-level assumption (that also works in places where we *can't* reasonably find this directory automatically otherwise).

See https://github.com/docker-library/meta-scripts/pull/124